### PR TITLE
:bug: Fix pr-checklist by using different github context variable

### DIFF
--- a/action-templates/actions/action-pr-checklist/action.yml
+++ b/action-templates/actions/action-pr-checklist/action.yml
@@ -11,9 +11,8 @@ runs:
   using: "composite"
   steps:
     - name: Configure checklist requirement
-      if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.event.pull_request.draft == false }}
+      if: ${{ github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]' }}
       uses: mheap/require-checklist-action@efef3b1b39d03d12be5ce427c15064f287ba5843 # v2
       with:
         requireChecklist: ${{ inputs.fail-missing }}
         skipDescriptionRegex: .*\(optional\).*
-        skipDescriptionRegexFlags: i


### PR DESCRIPTION
**Description**
- Changed checking of bot creation via `github.event.pull_request.user.login` variable
- Removed deprecated action input
