### PR TITLE
:sparkles: Add PR labeler action with external repo capability

### DIFF
--- a/action-templates/actions/action-pr-labeler/action.yml
+++ b/action-templates/actions/action-pr-labeler/action.yml
@@ -1,0 +1,26 @@
+name: PR Labeler
+
+inputs:
+  configuration-path:
+    required: false
+    default: ".github/labeler.yml"
+    type: string
+    description: Path to the configuration file
+  repository:
+    required: false
+    default: ""
+    type: string
+    description: Path to an repository to reference external configuration file
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout external repository
+      if: ${{ inputs.repository != '' }}
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: '${{ inputs.repository }}'
+    - name: Label PR
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+      with:
+        configuration-path: ${{ inputs.configuration-path }}

--- a/action-templates/actions/action-pr-labeler/action.yml
+++ b/action-templates/actions/action-pr-labeler/action.yml
@@ -19,7 +19,7 @@ runs:
       if: ${{ inputs.repository != '' }}
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        repository: '${{ inputs.repository }}'
+        repository: "${{ inputs.repository }}"
     - name: Label PR
       uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
       with:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -346,4 +346,20 @@ Action to enforce ticking of all checklist items inside a PR (useful for PR temp
     fail-missing: "false"
 ```
 
-Testline
+### action-pr-labeler
+
+Action to automatically label opened pull requests using the configuration file in `.github/labeler.yml` of the repositories.
+More information about the configuration of the `labeler.yml` file can be found in [official documentation](https://github.com/actions/labeler)
+
+<!-- prettier-ignore -->
+```yaml
+- uses: it-at-m/lhm_actions/action-templates/actions/action-pr-labeler
+  with:
+    # Path to the configuration file inside the repository
+    # Default: .github/labeler.yml
+    configuration-path: ".github/labeler.yml"
+    
+    # Optional repository to checkout to reference external configuration file
+    # Default: ""
+    repository: ""
+```


### PR DESCRIPTION
**Description**

- Add wrapper action for PR labeler functionality (see https://github.com/actions/labeler for more information)
- Added inputs to allow fetch from external repositories

**Reference**

Issues #30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated pull request labeling action featuring configurable options for tailoring the behavior.
	- Added inputs for specifying the configuration file path and referencing an external repository.
- **Documentation**
	- Added a new section detailing the usage of the pull request labeling action, including configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->