### PR TITLE
bug(maven-release): fix slash in app-path

### DIFF
--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -77,7 +77,7 @@ runs:
         git config --global user.email "github-actions@github.com"
         git config --global user.name "GitHub Actions"
         # get maven artifact id and provide as output
-        MVN_ARTIFACT_ID=$(mvn -f .${{inputs.app-path}}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)
+        MVN_ARTIFACT_ID=$(mvn -f ./${{inputs.app-path}}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)
         echo $MVN_ARTIFACT_ID
         echo "MVN_ARTIFACT_ID=$MVN_ARTIFACT_ID" >> $GITHUB_OUTPUT
         # run maven release


### PR DESCRIPTION
**Description**

- action-maven-release add missing slash before app path to unify path construction

**Reference**

- Issue: #42 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the file path syntax for locating the `pom.xml` file, ensuring reliable extraction of the artifact ID during Maven release actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->