### PR TITLE
fix(maven-release): fix use-pr boolean flag in mvn command

### DIFF
--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -84,7 +84,7 @@ runs:
         mvn release:prepare release:perform -f ./${{inputs.app-path}}/pom.xml -B \
           -DreleaseVersion=${{ inputs.releaseVersion }} -DdevelopmentVersion=${{ inputs.developmentVersion }} \
           -Darguments="-Dmaven.deploy.skip=${{ inputs.skipDeployment }}" \
-          -DpushChanges=${{ !inputs.use-pr }} \
+          -DpushChanges=${{ inputs.use-pr != 'true' }} \
           -DremoteTagging=false -DlocalCheckout=true
       env:
         SIGN_KEY_PASS: ${{ inputs.SIGN_KEY_PASS }}


### PR DESCRIPTION
**Description**

Fix maven-release pushChanges flag bool not parsed correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the Maven release process to ensure more accurate interpretation of input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->