### PR TITLE
maint: cleanup action inputs syntax

### DIFF
--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -1,27 +1,23 @@
 # https://vitepress.dev/guide/deploy#github-pages
-name: Build docs
+name: "Build docs"
 
 inputs:
   docs-path:
+    description: "Path to vitepress docs project"
     required: false
     default: "./docs"
-    type: string
-    description: Path to vitepress docs project
   node-version:
+    description: "Node version"
     required: false
     default: "22"
-    type: string
-    description: Node version
   build-cmd:
+    description: "Change build command, if using vuepress"
     required: false
     default: "build"
-    type: string
-    description: Change build command, if using vuepress
   dist-path:
+    description: "Vitepress output path, which should be uploaded to github pages"
     required: false
     default: ".vitepress/dist"
-    type: string
-    description: Vitepress output path, which should be uploaded to github pages
 
 runs:
   using: "composite"

--- a/action-templates/actions/action-checkout/action.yml
+++ b/action-templates/actions/action-checkout/action.yml
@@ -1,5 +1,6 @@
 name: "Checkout Code"
 description: "A wrapper for actions/checkout with no args"
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -17,13 +17,13 @@ inputs:
     required: false
     default: "security-and-quality"
   java-version:
+    description: "Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild)"
+    required: false
     default: "21"
-    type: string
-    description: Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild)
   path:
     description: "Path to scan files in"
-    required: false
     default: "."
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -22,6 +22,7 @@ inputs:
     default: "21"
   path:
     description: "Path to scan files in"
+    required: false
     default: "."
 
 runs:

--- a/action-templates/actions/action-create-github-release/action.yml
+++ b/action-templates/actions/action-create-github-release/action.yml
@@ -1,18 +1,17 @@
-name: Create GitHub Release
+name: "Create GitHub Release"
 description: "Creates a GitHub Release of a Maven Artifact"
+
 inputs:
   artifact-name:
-    required: true
-    type: string
     description: "name of the artifact to download"
+    required: true
   tag-name:
-    required: true
-    type: string
     description: "Name of a tag (e.g. sps-1.0.0 or myproject-1.0.0)"
-  artifact-path:
     required: true
-    type: string
+  artifact-path:
     description: "path to the artifacts (e.g. ./target/*.jar)"
+    required: true
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-dependency-review/action.yml
+++ b/action-templates/actions/action-dependency-review/action.yml
@@ -1,10 +1,11 @@
-name: dependency-review
+name: "dependency-review"
+
 inputs:
   allow-dependencies-licenses:
+    description: "Contains a comma separated string of packages that will be excluded from license checks"
     required: false
     default: ""
-    type: string
-    description: Contains a comma separated string of packages that will be excluded from license checks.
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-deploy-docs/action.yml
+++ b/action-templates/actions/action-deploy-docs/action.yml
@@ -1,15 +1,15 @@
-name: Deploy docs
+name: "Deploy docs"
+
 inputs:
   artifact_name:
     description: "The name of the artifact to deploy"
+    required: false
     default: "github-pages"
-    required: false
-    type: string
   deploy-branch:
-    required: false
-    type: string
-    default: "main"
     description: "Branch to deploy documentation from"
+    required: false
+    default: "main"
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-dockercompose-healthcheck/action.yml
+++ b/action-templates/actions/action-dockercompose-healthcheck/action.yml
@@ -5,11 +5,11 @@ inputs:
   max-retries:
     description: "Maximum number of retry attempts"
     required: false
-    default: 10
+    default: "10"
   retry-interval:
     description: "Interval between retries in seconds"
     required: false
-    default: 10
+    default: "10"
   compose-file-path:
     description: "Path to the docker compose file"
     required: false
@@ -21,11 +21,11 @@ inputs:
   skip-exited:
     description: "Skip checking exited containers (useful for init containers)"
     required: false
-    default: false
+    default: "false"
   skip-no-healthcheck:
     description: "Skip checking containers without health checks"
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: "composite"

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -1,7 +1,9 @@
 name: "Path Filter"
 description: "Paths filter with input of filters"
+
 inputs:
   filters:
+    description: "Defines filters applied to detected changed files"
     required: false
     default: |
       java:
@@ -16,8 +18,7 @@ inputs:
         - '**/*.vue'
       python:
         - '**/*.py'
-    type: string
-    description: Defines filters applied to detected changed files.
+
 outputs:
   java:
     description: "name of the artifact upload"
@@ -28,6 +29,7 @@ outputs:
   python:
     description: "name of the artifact upload"
     value: ${{ steps.filter.outputs.python }}
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -2,11 +2,11 @@ name: Compliance check and build test
 
 inputs:
   java-version:
-    description: "set the java version"
+    description: "Java version to use for the build"
     required: false
     default: "21"
   app-path:
-    description: "path to the pom.xml"
+    description: "Path to the project’s pom.xml file"
     required: true
 
 outputs:

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -2,18 +2,18 @@ name: Compliance check and build test
 
 inputs:
   java-version:
+    description: "set the java version"
     required: false
     default: "21"
-    type: string
-    description: set the java version
   app-path:
+    description: "path to the pom.xml"
     required: true
-    type: string
-    description: path to the pom.xml
+
 outputs:
   artifact-name:
     description: "name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -1,47 +1,37 @@
-name: Maven Release
+name: "Maven Release"
 
 inputs:
   java-version:
+    description: "configure the java version"
     required: false
-    default: 21
-    type: string
-    description: configure the java version
+    default: "21"
   app-path:
+    description: "path where the pom.xml is"
     required: true
-    type: string
-    description: path where the pom.xml is
   releaseVersion:
+    description: "version which will be released"
     required: true
-    type: string
-    description: version which will be released
   developmentVersion:
+    description: "next version with snapshot"
     required: true
-    type: string
-    description: next version with snapshot
   skipDeployment:
-    default: true
-    type: boolean
-    description: skip deployment to maven central
+    description: "skip deployment to maven central"
+    default: "true"
   use-pr:
-    default: false
-    type: boolean
-    description: use PR for version bump instead of direct push
+    description: "use PR for version bump instead of direct push"
+    default: "false"
   SIGN_KEY_PASS:
+    description: "env variable for GPG private key passphrase"
     required: true
-    type: string
-    description: env variable for GPG private key passphrase
   CENTRAL_USERNAME:
+    description: "env variable for username in deploy"
     required: true
-    type: string
-    description: env variable for username in deploy
   CENTRAL_PASSWORD:
+    description: "env variable for token in deploy"
     required: true
-    type: string
-    description: env variable for token in deploy
   GPG_PRIVATE_KEY:
+    description: "Value of the GPG private key to import"
     required: true
-    type: string
-    description: Value of the GPG private key to import
 
 outputs:
   MVN_ARTIFACT_ID:
@@ -80,6 +70,11 @@ runs:
         MVN_ARTIFACT_ID=$(mvn -f ./${{inputs.app-path}}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)
         echo $MVN_ARTIFACT_ID
         echo "MVN_ARTIFACT_ID=$MVN_ARTIFACT_ID" >> $GITHUB_OUTPUT
+
+        # determine maven arguments
+        if [[ "${{ inputs.skipDeployment }}" == "true" ]]; then
+          MAVEN_ARGS='-Darguments="-Dmaven.deploy.skip=true"'
+        fi
         # run maven release
         mvn release:prepare release:perform -f ./${{inputs.app-path}}/pom.xml -B \
           -DreleaseVersion=${{ inputs.releaseVersion }} -DdevelopmentVersion=${{ inputs.developmentVersion }} \

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -2,35 +2,35 @@ name: "Maven Release"
 
 inputs:
   java-version:
-    description: "configure the java version"
+    description: "Java version to use for the build"
     required: false
     default: "21"
   app-path:
-    description: "path where the pom.xml is"
+    description: "Path to the project’s pom.xml file"
     required: true
   releaseVersion:
-    description: "version which will be released"
+    description: "Version to be released"
     required: true
   developmentVersion:
-    description: "next version with snapshot"
+    description: "Next version with snapshot"
     required: true
   skipDeployment:
-    description: "skip deployment to maven central"
+    description: "Skip deployment to Maven Central"
     default: "true"
   use-pr:
-    description: "use PR for version bump instead of direct push"
+    description: "Use PR for version bump instead of direct push"
     default: "false"
+  GPG_PRIVATE_KEY:
+    description: "GPG private key to import"
+    required: true
   SIGN_KEY_PASS:
-    description: "env variable for GPG private key passphrase"
+    description: "Environment variable name for the GPG private key passphrase"
     required: true
   CENTRAL_USERNAME:
-    description: "env variable for username in deploy"
+    description: "Environment variable name for the username for authentication to Maven Central"
     required: true
   CENTRAL_PASSWORD:
-    description: "env variable for token in deploy"
-    required: true
-  GPG_PRIVATE_KEY:
-    description: "Value of the GPG private key to import"
+    description: "Environment variable name for password or token for authentication to Maven Central"
     required: true
 
 outputs:

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -70,11 +70,6 @@ runs:
         MVN_ARTIFACT_ID=$(mvn -f ./${{inputs.app-path}}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)
         echo $MVN_ARTIFACT_ID
         echo "MVN_ARTIFACT_ID=$MVN_ARTIFACT_ID" >> $GITHUB_OUTPUT
-
-        # determine maven arguments
-        if [[ "${{ inputs.skipDeployment }}" == "true" ]]; then
-          MAVEN_ARGS='-Darguments="-Dmaven.deploy.skip=true"'
-        fi
         # run maven release
         mvn release:prepare release:perform -f ./${{inputs.app-path}}/pom.xml -B \
           -DreleaseVersion=${{ inputs.releaseVersion }} -DdevelopmentVersion=${{ inputs.developmentVersion }} \

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -1,26 +1,27 @@
-name: Compliance check and build test
+name: "Compliance check and build test"
+
 inputs:
   node-version:
+    description: "node version"
     required: false
     default: "22"
-    type: string
-    description: node version
   app-path:
+    description: "path where the package.json is located"
     required: true
-    type: string
-    description: path where the package.json is located
   run-lint:
+    description: "Controls the execution of the 'npm run lint' script"
     required: false
     default: "true"
-    description: Controls the execution of the 'npm run lint' script
   run-test:
+    description: "Controls the execution of the 'npm run test' script"
     required: false
     default: "true"
-    description: Controls the execution of the 'npm run test' script
+
 outputs:
   artifact-name:
     description: name of the artifact upload
     value: ${{steps.artifact-name.outputs.artifact-name}}
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -1,35 +1,28 @@
-name: Npm Release
+name: "Npm Release"
 
 inputs:
   node-version:
+    description: "node version"
     required: false
     default: "22"
-    type: string
-    description: node version
   app-path:
+    description: "path where the package.json is located"
     required: true
-    type: string
-    description: path where the package.json is located
   releaseVersion:
-    type: choice
-    description: Select version increment type (follows Semantic Versioning)
+    description: "Select version increment type (follows Semantic Versioning)"
     required: true
-    options:
-      - patch
-      - minor
-      - major
   npm-token:
-    type: string
+    description: "npm token for release"
     required: true
-    description: npm token for release
   use-pr:
-    default: false
-    type: boolean
-    description: use PR for version bump instead of direct push
+    description: "use PR for version bump instead of direct push"
+    default: "false"
+
 outputs:
   ARTIFACT_VERSION:
     description: version of the artifact upload
     value: ${{steps.node-release.outputs.VERSION}}
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-pr-checklist/action.yml
+++ b/action-templates/actions/action-pr-checklist/action.yml
@@ -1,11 +1,10 @@
-name: Require PR checklist
+name: "Require PR checklist"
 
 inputs:
   fail-missing:
+    description: "Whether the action should fail if the PR contains no checklist"
     required: false
     default: "false"
-    type: string
-    description: Whether the action should fail if the PR contains no checklist
 
 runs:
   using: "composite"

--- a/action-templates/actions/action-pr-labeler/action.yml
+++ b/action-templates/actions/action-pr-labeler/action.yml
@@ -1,16 +1,14 @@
-name: PR Labeler
+name: "PR Labeler"
 
 inputs:
   configuration-path:
+    description: "Path to the configuration file"
     required: false
     default: ".github/labeler.yml"
-    type: string
-    description: Path to the configuration file
   repository:
+    description: "Path to an repository to reference external configuration file"
     required: false
     default: ""
-    type: string
-    description: Path to an repository to reference external configuration file
 
 runs:
   using: "composite"

--- a/action-templates/actions/action-pr-labeler/action.yml
+++ b/action-templates/actions/action-pr-labeler/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: ".github/labeler.yml"
   repository:
-    description: "Path to an repository to reference external configuration file"
+    description: "Path to a repository to reference external configuration file"
     required: false
     default: ""
 


### PR DESCRIPTION
**Description**

Cleanup action inputs to match specification: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs
- Rm types
- Default as string
- Add spacing around yaml root elements
- Order input attributes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting and consistency of action metadata, including quoting action names and reordering fields for clarity.
- **Documentation**
  - Added or updated descriptions for input parameters and outputs across multiple actions to enhance clarity for users.
- **Chores**
  - Removed unnecessary type declarations and updated default values to use string literals for better compatibility.
  - Minor metadata reorganization and formatting adjustments for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->