### PR TITLE
fix(maven-release): deploy skip overwriting pom

### DIFF
--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -80,12 +80,16 @@ runs:
         MVN_ARTIFACT_ID=$(mvn -f ./${{inputs.app-path}}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.artifactId -q -DforceStdout)
         echo $MVN_ARTIFACT_ID
         echo "MVN_ARTIFACT_ID=$MVN_ARTIFACT_ID" >> $GITHUB_OUTPUT
+        # prepare the maven arguments
+        MAVEN_ARGS="-DpushChanges=${{ inputs.use-pr != 'true' }} -DremoteTagging=false -DlocalCheckout=true"
+        # set maven deploy skip if skipDeployment is true
+        if [[ "${{ inputs.skipDeployment }}" == "true" ]]; then
+          MAVEN_ARGS="$MAVEN_ARGS -Darguments=\"-Dmaven.deploy.skip=true\""
+        fi
         # run maven release
         mvn release:prepare release:perform -f ./${{inputs.app-path}}/pom.xml -B \
           -DreleaseVersion=${{ inputs.releaseVersion }} -DdevelopmentVersion=${{ inputs.developmentVersion }} \
-          -Darguments="-Dmaven.deploy.skip=${{ inputs.skipDeployment }}" \
-          -DpushChanges=${{ inputs.use-pr != 'true' }} \
-          -DremoteTagging=false -DlocalCheckout=true
+          $MAVEN_ARGS
       env:
         SIGN_KEY_PASS: ${{ inputs.SIGN_KEY_PASS }}
         CENTRAL_USERNAME: ${{ inputs.CENTRAL_USERNAME }}

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -84,7 +84,7 @@ runs:
         MAVEN_ARGS="-DpushChanges=${{ inputs.use-pr != 'true' }} -DremoteTagging=false -DlocalCheckout=true"
         # set maven deploy skip if skipDeployment is true
         if [[ "${{ inputs.skipDeployment }}" == "true" ]]; then
-          MAVEN_ARGS="$MAVEN_ARGS -Darguments=\"-Dmaven.deploy.skip=true\""
+          MAVEN_ARGS="$MAVEN_ARGS -Darguments='-Dmaven.deploy.skip=true'"
         fi
         # run maven release
         mvn release:prepare release:perform -f ./${{inputs.app-path}}/pom.xml -B \


### PR DESCRIPTION
**Description**

Only set deploy.skip if input true to allow mode where setting is taken from pom.
Otherwise overwrites POM, which breaks projects with mixed deploy settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of Maven command-line arguments for the release process, centralizing argument construction and streamlining configuration. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->