### PR TITLE
fix(maven-release): fix setup-java varname instead of value

### DIFF
--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -55,10 +55,10 @@ runs:
         cache: "maven"
         cache-dependency-path: "./${{ inputs.app-path}}/pom.xml"
         server-id: "central"
-        server-username: ${{ inputs.CENTRAL_USERNAME }}
-        server-password: ${{ inputs.CENTRAL_PASSWORD }}
+        server-username: CENTRAL_USERNAME
+        server-password: CENTRAL_PASSWORD
         gpg-private-key: ${{ inputs.GPG_PRIVATE_KEY }}
-        gpg-passphrase: ${{ inputs.SIGN_KEY_PASS }}
+        gpg-passphrase: SIGN_KEY_PASS
     - name: Maven Release Step
       id: maven-release-step
       shell: bash


### PR DESCRIPTION
**Description**

maven-release: fix setup-java requires var name instead of value. See https://github.com/actions/setup-java?tab=readme-ov-file#maven-options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the way Maven Central credentials and GPG passphrase are referenced in the release workflow configuration. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->