### PR TITLE
add npm ocid

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -208,4 +208,4 @@ The npm-default is that scoped packages are only published private. You need to 
 ```
 
 1. If someone has a new project that they want to publish on npm, an npm admin must enable the trusted publisher, according to the [documentation](https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom).
-1. The GitHub actions must be granted the appropriate permissions. See the [documentation](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow).
+1. The GitHub Actions must be granted the appropriate permissions. See the [documentation](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow).


### PR DESCRIPTION
Added steps for enabling trusted publishers and configuring GitHub actions.

**Description**

Short description or comments

**Reference**

Issues internes Issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NPM publishing guidance to include enabling the trusted publisher.
  * Added steps for configuring GitHub Actions CI/CD permissions for npm publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->