### PR TITLE
Replace codeql version from v3 to v3.31.10

### DIFF
--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -39,17 +39,17 @@ runs:
         cache: "maven"
         cache-dependency-path: "${{ inputs.path }}/pom.xml"
     - name: Initialize CodeQL for ${{ inputs.codeql-language }}
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v3.31.10
       with:
         languages: ${{ inputs.codeql-language }}
         build-mode: ${{ inputs.codeql-buildmode }}
         queries: ${{ inputs.codeql-query }}
     - if: inputs.codeql-buildmode == 'autobuild'
       name: Build using autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v3.31.10
       with:
         working-directory: ${{ inputs.path }}
     - name: Perform CodeQL analysis for ${{ inputs.codeql-language }}
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v3.31.10
       with:
         category: "/language:${{ inputs.codeql-language }}-/path:${{ inputs.path }}"


### PR DESCRIPTION
**Description**

Changed version setting from v3 to v3.31.10 so that renovate will also generate PRs for CodeQL

**Reference**

Issues #157 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned CodeQL action versions to specific patch releases (v3.31.10) across all workflow steps to ensure consistent and reproducible security scanning, replacing generic version tags with more granular version specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->