### PR TITLE
fix: update several actions

### DIFF
--- a/.github/workflows/action-reviewdog.yml
+++ b/.github/workflows/action-reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0

--- a/.github/workflows/action-superlint.yml
+++ b/.github/workflows/action-superlint.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits

--- a/.github/workflows/action-superlint.yml
+++ b/.github/workflows/action-superlint.yml
@@ -48,7 +48,7 @@ jobs:
         if: >
           github.event_name == 'pull_request' &&
           github.ref_name != github.event.repository.default_branch
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
           commit_message: "chore: fix linting issues [skip ci]"

--- a/.github/workflows/dependency_review.yaml
+++ b/.github/workflows/dependency_review.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Dependency Review

--- a/.github/workflows/dependency_review.yaml
+++ b/.github/workflows/dependency_review.yaml
@@ -12,6 +12,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           config-file: it-at-m/.github/workflow-configs/dependency_review.yaml@main

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/test-action-npm-build.yml
+++ b/.github/workflows/test-action-npm-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-local-actions
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test-action-npm-release.yml
+++ b/.github/workflows/test-action-npm-release.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: checkout-local-actions
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/action-templates/actions/action-actionlint/action.yml
+++ b/action-templates/actions/action-actionlint/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Download actionlint

--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -29,7 +29,7 @@ runs:
         fetch-depth: 0 # Required for vitepress lastUpdated
         persist-credentials: false
     - name: Setup Node
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm

--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0 # Required for vitepress lastUpdated
         persist-credentials: false

--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -46,6 +46,6 @@ runs:
         npm --prefix "$DOCS_PATH" run  lint
         npm --prefix "$DOCS_PATH" run "$BUILD_CMD"
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: ${{ inputs.docs-path }}/${{ inputs.dist-path }}

--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -35,7 +35,7 @@ runs:
         cache: npm
         cache-dependency-path: "${{ inputs.docs-path }}/package-lock.json"
     - name: Setup Pages
-      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
     - name: Run ci lint build
       shell: bash
       env:

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Download a single artifact

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -40,7 +40,7 @@ runs:
       with:
         persist-credentials: false
     - name: Download a single artifact
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact-name }}
     - name: Login to registry

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -58,7 +58,7 @@ runs:
         labels: ${{inputs.image-labels}}
 
     - name: Build and push image
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
       with:
         context: ./${{ inputs.path }} # zizmor: ignore[template-injection]
         push: true

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -44,7 +44,7 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
     - name: Login to registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -51,7 +51,7 @@ runs:
         password: ${{ inputs.registry-password }}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       with:
         images: "${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image-name }}"
         tags: ${{inputs.image-tags}}

--- a/action-templates/actions/action-checkout/action.yml
+++ b/action-templates/actions/action-checkout/action.yml
@@ -11,11 +11,11 @@ runs:
   steps:
     - name: Checkout repository without persisting credentials
       if: ${{ inputs.persist-credentials != 'true' }}
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Checkout repository with persisting credentials
       if: ${{ inputs.persist-credentials == 'true' }}
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: true

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -29,7 +29,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up JDK

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -41,17 +41,17 @@ runs:
         cache: "maven"
         cache-dependency-path: "${{ inputs.path }}/pom.xml"
     - name: Initialize CodeQL for ${{ inputs.codeql-language }}
-      uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         languages: ${{ inputs.codeql-language }}
         build-mode: ${{ inputs.codeql-buildmode }}
         queries: ${{ inputs.codeql-query }}
     - if: inputs.codeql-buildmode == 'autobuild'
       name: Build using autobuild
-      uses: github/codeql-action/autobuild@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+      uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         working-directory: ${{ inputs.path }}
     - name: Perform CodeQL analysis for ${{ inputs.codeql-language }}
-      uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         category: "/language:${{ inputs.codeql-language }}-/path:${{ inputs.path }}"

--- a/action-templates/actions/action-create-github-release/action.yml
+++ b/action-templates/actions/action-create-github-release/action.yml
@@ -28,7 +28,7 @@ runs:
         name: ${{inputs.artifact-name}}
     - name: Create GitHub release
       id: create_release
-      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         tag_name: ${{inputs.tag-name}}
         draft: ${{inputs.draft == 'true'}}

--- a/action-templates/actions/action-create-github-release/action.yml
+++ b/action-templates/actions/action-create-github-release/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Download a single artifact
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{inputs.artifact-name}}
     - name: Create GitHub release

--- a/action-templates/actions/action-dependency-review/action.yml
+++ b/action-templates/actions/action-dependency-review/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Dependency review

--- a/action-templates/actions/action-dependency-review/action.yml
+++ b/action-templates/actions/action-dependency-review/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         persist-credentials: false
     - name: Dependency review
-      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
       with:
         config-file: it-at-m/.github/workflow-configs/dependency_review.yaml@main
         allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses }}

--- a/action-templates/actions/action-deploy-docs/action.yml
+++ b/action-templates/actions/action-deploy-docs/action.yml
@@ -17,6 +17,6 @@ runs:
     - name: Deploy to GitHub Pages
       id: deployment
       if: (github.ref_name == inputs.deploy-branch)
-      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
       with:
         artifact_name: ${{ inputs.artifact_name }}

--- a/action-templates/actions/action-dockercompose-healthcheck/action.yml
+++ b/action-templates/actions/action-dockercompose-healthcheck/action.yml
@@ -31,7 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Start Docker Compose services

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -35,6 +35,6 @@ runs:
   steps:
     - name: Check changed files and directories
       id: filter
-      uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: ${{ inputs.filters }}

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up JDK

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
     - id: upload-artifact
       name: Upload artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/target"

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -106,7 +106,7 @@ runs:
 
     - name: Push changes to release branch and create pull request
       if: ${{ inputs.use-pr == 'true' }}
-      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         title: "chore(${{ inputs.app-path }}): bump release version to ${{ inputs.developmentVersion }}"
         branch: "release-${{ inputs.app-path }}-${{ inputs.developmentVersion }}"

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -98,7 +98,7 @@ runs:
       run: echo "artifact-name=${{hashFiles(format('./{0}/pom.xml', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Upload artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/target"

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     # Checkout source code, set up Java, etc. Then...
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: true
     - name: Set up JDK

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -59,7 +59,7 @@ runs:
       run: echo "artifact-name=${{hashFiles(format('./{0}/package.json', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Upload artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/dist"

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: "npm"

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -29,7 +29,7 @@ runs:
       with:
         persist-credentials: true
     - name: Set up Node.js
-      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "${{ inputs.node-version }}"
         registry-url: "https://registry.npmjs.org"

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -57,7 +57,7 @@ runs:
 
     - name: Push changes to release branch and create pull request
       if: ${{ inputs.use-pr == 'true' }}
-      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         title: "chore(${{ inputs.app-path }}): bump release version to ${{ env.NEW_VERSION }}"
         branch: "release-${{ inputs.app-path }}-${{ steps.node-release.outputs.VERSION }}"

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: true
     - name: Set up Node.js

--- a/action-templates/actions/action-pr-labeler/action.yml
+++ b/action-templates/actions/action-pr-labeler/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Checkout external repository
       if: ${{ inputs.repository != '' }}
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: "${{ inputs.repository }}"
         persist-credentials: false

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0 # Required for vitepress lastUpdated
         persist-credentials: false

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -38,7 +38,7 @@ runs:
         trivy convert --format sarif --output trivy-results.sarif  trivy-report.json
 
     - name: Upload Vulnerability Scan Results
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: trivy-report


### PR DESCRIPTION
# Pull Request

## Changes

- update diverse actions

## Reference

Relates to #1

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : ...


- actionlint:  https://github.com/it-at-m/sps/actions/runs/25715418357
- build: https://github.com/it-at-m/sps/actions/runs/25715418368
- codeql: https://github.com/it-at-m/sps/actions/runs/25715418351
- dependency-review: https://github.com/it-at-m/sps/actions/runs/25715428361 > Deprecation Warning: The deny-licenses option is deprecated for possible removal in the next major release. For more information, see issue [dependency-review-action/issue/997](https://github.com/actions/dependency-review-action/issues/997).
- deploy-docs https://github.com/it-at-m/sps/actions/runs/25715418408
- docker-healthcheck: https://github.com/it-at-m/sps/actions/runs/25715418369 
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- pr-labeler: https://github.com/it-at-m/sps/actions/runs/25715427700
- release-maven: https://github.com/it-at-m/sps/actions/runs/25715959480
- release-npm: https://github.com/it-at-m/sps/actions/runs/25716137560
- trivy: https://github.com/it-at-m/sps/actions/runs/25715418363 
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [ ] Met all acceptance criteria of the issue
- [ ] Added meaningful PR title and list of changes in the description
- [ ] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [ ] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [ ] Wrote code and comments in English
- [ ] Coming soon: Added unit tests
