### PR TITLE
fix: use full length commit sha for upload-artif action

### DIFF
--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -1,0 +1,19 @@
+# Workflow for running security scan using Trivy
+name: trivy
+
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * 1'
+      timezone: "Europe/Berlin"
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required to upload SARIF results to the GitHub Security tab
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
+    steps:
+      - uses: ./action-templates/actions/action-trivy

--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -1,12 +1,8 @@
 # Workflow for running security scan using Trivy
-name: trivy
+name: Test action action-trivy
 
 on:
-  push:
   workflow_dispatch:
-  schedule:
-    - cron: '30 5 * * 1'
-      timezone: "Europe/Berlin"
 
 jobs:
   trivy:
@@ -14,6 +10,5 @@ jobs:
     permissions:
       contents: read
       security-events: write # Required to upload SARIF results to the GitHub Security tab
-    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
     steps:
       - uses: ./action-templates/actions/action-trivy

--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -12,4 +12,9 @@ jobs:
       contents: read
       security-events: write # Required to upload SARIF results to the GitHub Security tab
     steps:
+      - name: checkout-local-actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: ./action-templates/actions/action-trivy

--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -2,6 +2,7 @@
 name: Test action action-trivy
 
 on:
+  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -2,14 +2,16 @@
 name: Test action action-trivy
 
 on:
-  push:
   workflow_dispatch:
 
+permissions:
+  contents: read # for checkout
+
 jobs:
-  trivy:
+  test-trivy:
+    name: test-trivy
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       security-events: write # Required to upload SARIF results to the GitHub Security tab
     steps:
       - name: checkout-local-actions

--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -2,6 +2,12 @@
 name: Test action action-trivy
 
 on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-trivy.yml
+++ b/.github/workflows/test-trivy.yml
@@ -4,10 +4,10 @@ name: Test action action-trivy
 on:
   pull_request:
     types:
-    - opened
-    - synchronize
-    - reopened
-    - ready_for_review
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch:
 
 permissions:

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -47,6 +47,6 @@ runs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.4
       with:
         sarif_file: "trivy-results.sarif"

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -47,6 +47,6 @@ runs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
-      uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.4
+      uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
# Pull Request

## Changes

- Changed versioning from v4 to full-length commit SHA
- Added test-workflow test-trivy.yml

## Reference

Relates to #270 

### Testing

URL to pull request or branch for testing your changes ~~in [sps-repo](https://github.com/it-at-m/sps)~~ : 

- https://github.com/it-at-m/lhm_actions/actions/runs/25783557693

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [ ] ~~Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)~~
- [x] Tested changes with test action ~~sample project <https://github.com/it-at-m/sps>~~

### Code

- [x] Wrote code and comments in English
- [x] Added unit tests: test-trivy.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning to the CI/CD pipeline using Trivy.
  * Pinned security-related action dependencies to specific versions for improved consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/lhm_actions/pull/271)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->