### PR TITLE
fix: 250 rm deploy from default workflows#1616

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm install -g semantic-release
           npm install -g @semantic-release/exec

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -23,16 +23,16 @@ inputs:
     default: "false"
   GPG_PRIVATE_KEY:
     description: "GPG private key to import"
-    required: true
+    required: false
   SIGN_KEY_PASS:
     description: "Environment variable name for the GPG private key passphrase"
-    required: true
+    required: false
   CENTRAL_USERNAME:
     description: "Environment variable name for the username for authentication to Maven Central"
-    required: true
+    required: false
   CENTRAL_PASSWORD:
     description: "Environment variable name for password or token for authentication to Maven Central"
-    required: true
+    required: false
 
 outputs:
   MVN_ARTIFACT_ID:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -493,16 +493,16 @@ Workflows using that action need the following permissions:
     # default: false
     use-pr: "true"
 
-    # Environment variable for GPG private key passphrase
+    # Optional: Environment variable for GPG private key passphrase
     SIGN_KEY_PASS: ${{ secrets.gpg_passphrase }}
 
-    # Environment variable for Maven central username
+    # Optional: Environment variable for Maven central username
     CENTRAL_USERNAME: ${{ secrets.sonatype_username }}
 
-    # Env variable for Maven central token
+    # Optional:  Env variable for Maven central token
     CENTRAL_PASSWORD: ${{ secrets.sonatype_password }}
 
-    # Value of the GPG private key to import
+    # Optional:  Value of the GPG private key to import
     GPG_PRIVATE_KEY: ${{ secrets.gpg_private_key }}
 ```
 


### PR DESCRIPTION
Changed required fields to optional for GPG and Maven Central credentials.

# Pull Request

## Changes
because of security issues

- remove tokens for publish to maven central
- token to npm registry


## Reference

Relates to #250

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : ...

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [ ] Met all acceptance criteria of the issue
- [ ] Added meaningful PR title and list of changes in the description
- [ ] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [ ] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [ ] Wrote code and comments in English
- [ ] Coming soon: Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication configuration.
  * Made credential inputs optional in the Maven release action.

* **Documentation**
  * Updated documentation to reflect optional credential requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/lhm_actions/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->