### PR TITLE
feat(trivy): option to allow failure and custom path

### DIFF
--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -41,3 +41,6 @@ runs:
       uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: ${{ inputs.filters }}
+    - run: |
+        echo ${{ toJSON(steps.filter.outputs.changes) }}
+      shell: bash

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -29,7 +29,7 @@ outputs:
   python:
     description: "Name of the python artifact upload"
     value: ${{ steps.filter.outputs.python }}
-  change:
+  changes:
     description: folders that changes
     value: ${{ steps.filter.outputs.changes }}
 

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -29,7 +29,10 @@ outputs:
   python:
     description: "Name of the python artifact upload"
     value: ${{ steps.filter.outputs.python }}
-
+  change:
+    description: folders that changes
+    value: ${{ steps.filter.outputs.changes }}
+  
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -30,7 +30,7 @@ outputs:
     description: "Name of the python artifact upload"
     value: ${{ steps.filter.outputs.python }}
   changes:
-    description: folders that changes
+    description: "JSON array of filter names that have matched changes"
     value: ${{ steps.filter.outputs.changes }}
 
 runs:

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -41,6 +41,3 @@ runs:
       uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       with:
         filters: ${{ inputs.filters }}
-    - run: |
-        echo ${{ toJSON(steps.filter.outputs.changes) }}
-      shell: bash

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -32,7 +32,7 @@ outputs:
   change:
     description: folders that changes
     value: ${{ steps.filter.outputs.changes }}
-  
+
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -13,7 +13,7 @@ inputs:
   allow-failure:
     description: "If the action should succeed even if trivy fails"
     required: false
-    default: 'false'
+    default: "false"
 
 runs:
   using: "composite"

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "timeout for trivy scan"
     required: false
     default: 15m0s
+  allow-failure:
+    description: "If the action should succeed even if trivy fails"
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -21,6 +25,7 @@ runs:
         persist-credentials: false
     - name: Run Trivy vulnerability scanner in repository mode
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      continue-on-error: ${{ inputs.allow-failure == 'true' }}
       env:
         TRIVY_INCLUDE_DEV_DEPS: "true"
       with:

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -7,15 +7,15 @@ inputs:
     required: false
     default: ".trivyignore"
   timeout:
-    description: "timeout for trivy scan"
+    description: "Timeout for Trivy scan"
     required: false
     default: 15m0s
   allow-failure:
-    description: "If the action should succeed even if trivy fails"
+    description: "If the action should succeed even if Trivy fails"
     required: false
     default: "false"
   path:
-    description: "Path to run trivy at"
+    description: "Path to run Trivy at"
     required: false
     default: "."
 

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: "false"
   path:
-    description: "Path to run Trivy at"
+    description: "Path to scan with Trivy"
     required: false
     default: "."
 
@@ -29,7 +29,6 @@ runs:
         persist-credentials: false
     - name: Run Trivy vulnerability scanner in repository mode
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-      continue-on-error: ${{ inputs.allow-failure == 'true' }}
       env:
         TRIVY_INCLUDE_DEV_DEPS: "true"
       with:

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: "Timeout for Trivy scan"
     required: false
     default: 15m0s
-  allow-failure:
-    description: "If the action should succeed even if Trivy fails"
-    required: false
-    default: "false"
   path:
     description: "Path to scan with Trivy. For scan-type=sbom, this must point to a specific SBOM file (e.g. sbom.cdx.json), not a directory."
     required: false
@@ -40,7 +36,7 @@ runs:
         scan-type: "${{ inputs.scan-type }}"
         scan-ref: "${{ inputs.path }}"
         format: "json"
-        exit-code: ${{ inputs.allow-failure == 'true' && '0' || '1' }}
+        exit-code: "1"
         timeout: "${{ inputs.timeout }}"
         trivyignores: ${{ inputs.trivyignore-files }}
         output: trivy-report.json

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -36,7 +36,7 @@ runs:
         scan-type: "fs"
         scan-ref: ${{ inputs.path }}
         format: "json"
-        exit-code: "1"
+        exit-code: ${{ inputs.allow-failure == 'true' && '0' || '1' }}
         timeout: "${{ inputs.timeout }}"
         trivyignores: ${{ inputs.trivyignore-files }}
         output: trivy-report.json

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "If the action should succeed even if trivy fails"
     required: false
     default: "false"
+  path:
+    description: "Path to run trivy at"
+    required: false
+    default: "."
 
 runs:
   using: "composite"
@@ -30,7 +34,7 @@ runs:
         TRIVY_INCLUDE_DEV_DEPS: "true"
       with:
         scan-type: "fs"
-        scan-ref: "."
+        scan-ref: ${{ inputs.path }}
         format: "json"
         exit-code: "1"
         timeout: "${{ inputs.timeout }}"

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -223,7 +223,7 @@ Executes the following steps:
 
 Output parameters:
 
-- For each filter (java, javascript-typescript-vue, python), it sets output variable named by the filter to the text:
+- For each filter (Java, javascript-typescript-vue, python), it sets output variable named by the filter to the text:
   - 'true' - if any of changed files matches any of filter rules
   - 'false' - if none of changed files matches any of filter rules
 - 'changes' - JSON array with names of all filters matching any of the changed files.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -679,7 +679,7 @@ Workflows using that action need the following permissions:
     # Default: false
     allow-failure: "false"
     # scan type, e.g. fs or sbom
-    # defualt: fs
+    # default: fs
     scan-type: fs
     # Path to scan with Trivy
     # Default: .

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -223,7 +223,7 @@ Executes the following steps:
 
 Output parameters:
 
-- For each filter, it sets output variable named by the filter to the text:
+- For each filter (java, javascript-typescript-vue, python), it sets output variable named by the filter to the text:
   - 'true' - if any of changed files matches any of filter rules
   - 'false' - if none of changed files matches any of filter rules
 - 'changes' - JSON array with names of all filters matching any of the changed files.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -656,4 +656,13 @@ Workflows using that action need the following permissions:
     # Relative Path to the trivyignore files
     # Default: ".trivyignore"
     trivyignore-files: ".trivyignore"
+    # Timeout for Trivy scan
+    # Default: 15m
+    timeout: "15m0s"
+    # If the action should succeed even if Trivy fails
+    # Default: false
+    allow-failure: "false"
+    # Path to run Trivy at
+    # Default: .
+    path: "."
 ```

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -675,9 +675,6 @@ Workflows using that action need the following permissions:
     # Timeout for Trivy scan
     # Default: 15m0s
     timeout: "15m0s"
-    # If the action should succeed even if Trivy fails
-    # Default: false
-    allow-failure: "false"
     # scan type, e.g. fs or sbom
     # default: fs
     scan-type: fs

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -657,12 +657,12 @@ Workflows using that action need the following permissions:
     # Default: ".trivyignore"
     trivyignore-files: ".trivyignore"
     # Timeout for Trivy scan
-    # Default: 15m
+    # Default: 15m0s
     timeout: "15m0s"
     # If the action should succeed even if Trivy fails
     # Default: false
     allow-failure: "false"
-    # Path to run Trivy at
+    # Path to scan with Trivy
     # Default: .
     path: "."
 ```

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -226,6 +226,7 @@ Output parameters:
 - For each filter, it sets output variable named by the filter to the text:
   - 'true' - if any of changed files matches any of filter rules
   - 'false' - if none of changed files matches any of filter rules
+- 'changes' - JSON array with names of all filters matching any of the changed files.
 
 Workflows using that action need the following permissions:
 


### PR DESCRIPTION
# Pull Request

## Changes

- feat(trivy): add input to allow failure
- feat(trivy): add input to run from custom path

## Reference

Relates to #292

### Testing

- with `allow-failure: true`: https://github.com/it-at-m/Praktikumsplaner/actions/runs/27279328222/job/80569120222
- with `path: './praktikumsplaner-backend'`: https://github.com/it-at-m/Praktikumsplaner/actions/runs/27279880102/job/80571114370
- https://github.com/it-at-m/sps/pull/65
- https://github.com/it-at-m/sps/tree/conditional-ausfuehrung

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : ...

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- ~~[ ] Met all acceptance criteria of the issue~~ only part of the solution
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [x] Wrote code and comments in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trivy Dependency Scan now supports a configurable `path` to choose what to scan (default: current directory).
  * Added `allow-failure` to control whether the action fails when Trivy reports issues (default: false).
  * Action Filter now provides an additional `changes` output with the set of changed filter names.
* **Documentation**
  * Updated Trivy action docs to document `timeout`, `allow-failure`, and `path`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->