### PR TITLE
297 trivy often failing maven dependency scanning

### DIFF
--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -14,6 +14,8 @@ outputs:
   artifact-name:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
+  cyclone-artifact-id:
+    value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
     value:  ${{steps.artifact-name.outputs.cyclone-path}}
 
@@ -49,10 +51,11 @@ runs:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/target"
         retention-days: 5
-    - id: upload-artifact1
-      name: Upload artifact1
+    - id: upload-sbom-artifact
+      name: upload-sbom-artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{inputs.app-path}}
         path: "${{inputs.app-path}}/target/classes/META-INF/sbom/application.cdx.json"
         retention-days: 5
+        archive: false

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -15,7 +15,7 @@ outputs:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
   cyclone-artifact-id:
-    description: "id of the sbom artifact"
+    description: "ID of the sbom artifact"
     value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
     description: "path of the sbom"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -15,8 +15,10 @@ outputs:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
   cyclone-artifact-id:
+    description: "id of the sbom artifact"
     value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
+    description: "path of the sbom"
     value: ${{steps.artifact-name.outputs.cyclone-path}}
 
 runs:

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -14,6 +14,8 @@ outputs:
   artifact-name:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
+  cyclone-path:
+    value:  ${{steps.artifact-name.outputs.cyclone-path}}
 
 runs:
   using: "composite"
@@ -36,7 +38,9 @@ runs:
       shell: bash
     - id: artifact-name
       name: Set output variable $GITHUB_OUTPUT
-      run: echo "artifact-name=${{hashFiles(format('./{0}/pom.xml', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
+      run: |
+         echo "artifact-name=${{hashFiles(format('./{0}/pom.xml', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
+         echo "cyclone-path=${{inputs.app-path}}/target/classes/META-INF/sbom/application.cdx.json" >> "$GITHUB_OUTPUT"
       shell: bash
     - id: upload-artifact
       name: Upload artifact

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -45,3 +45,10 @@ runs:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/target"
         retention-days: 5
+    - id: upload-artifact1
+      name: Upload artifact1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{inputs.app-path}}
+        path: "${{inputs.app-path}}/target/classes/META-INF/sbom/application.cdx.json"
+        retention-days: 5

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -17,7 +17,7 @@ outputs:
   cyclone-artifact-id:
     value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
-    value:  ${{steps.artifact-name.outputs.cyclone-path}}
+    value: ${{steps.artifact-name.outputs.cyclone-path}}
 
 runs:
   using: "composite"
@@ -43,8 +43,8 @@ runs:
       env:
         APP_PATH: ${{inputs.app-path}}
       run: |
-         echo "artifact-name=${{hashFiles(format('./{0}/pom.xml', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
-         echo "cyclone-path=$APP_PATH/target/classes/META-INF/sbom/application.cdx.json" >> "$GITHUB_OUTPUT"
+        echo "artifact-name=${{hashFiles(format('./{0}/pom.xml', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
+        echo "cyclone-path=$APP_PATH/target/classes/META-INF/sbom/application.cdx.json" >> "$GITHUB_OUTPUT"
       shell: bash
     - id: upload-artifact
       name: Upload artifact

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -40,9 +40,11 @@ runs:
       shell: bash
     - id: artifact-name
       name: Set output variable $GITHUB_OUTPUT
+      env:
+        APP_PATH: ${{inputs.app-path}}
       run: |
          echo "artifact-name=${{hashFiles(format('./{0}/pom.xml', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
-         echo "cyclone-path=${{inputs.app-path}}/target/classes/META-INF/sbom/application.cdx.json" >> "$GITHUB_OUTPUT"
+         echo "cyclone-path=$APP_PATH/target/classes/META-INF/sbom/application.cdx.json" >> "$GITHUB_OUTPUT"
       shell: bash
     - id: upload-artifact
       name: Upload artifact

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -59,9 +59,11 @@ runs:
       shell: bash
     - id: artifact-name
       name: Sets output variable $GITHUB_OUTPUT
+      env:
+        APP_PATH: ${{inputs.app-path}}
       run: |
         echo "artifact-name=${{hashFiles(format('./{0}/package.json', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
-        echo "cyclone-path=${{inputs.app-path}}/dist/application.cdx.json" >> "$GITHUB_OUTPUT"
+        echo "cyclone-path=$APP_PATH/dist/application.cdx.json" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Upload artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -70,10 +70,9 @@ runs:
         path: "**/dist"
         retention-days: 5
     - id: upload-sbom-artifact
-      name: Upload artifact1
+      name: upload-sbom-artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        # name: ${{inputs.app-path}}
         path: "${{inputs.app-path}}/dist/application.cdx.json"
         retention-days: 5
         archive: false

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -74,4 +74,4 @@ runs:
         name: ${{inputs.app-path}}
         path: "${{inputs.app-path}}/dist/application.cdx.json"
         retention-days: 5
-        archive: false
+        # archive: false

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -23,9 +23,11 @@ outputs:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
   cyclone-artifact-id:
+    description: "id of the sbom artifact"
     value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
     value: ${{steps.artifact-name.outputs.cyclone-path}}
+    description: "path of the sbom"
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -22,7 +22,8 @@ outputs:
   artifact-name:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
-
+  cyclone-path:
+    value:  ${{steps.artifact-name.outputs.cyclone-path}}
 runs:
   using: "composite"
   steps:
@@ -56,7 +57,9 @@ runs:
       shell: bash
     - id: artifact-name
       name: Sets output variable $GITHUB_OUTPUT
-      run: echo "artifact-name=${{hashFiles(format('./{0}/package.json', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "artifact-name=${{hashFiles(format('./{0}/package.json', inputs.app-path))}}" >> "$GITHUB_OUTPUT"
+        echo "cyclone-path=${{inputs.app-path}}/dist/application.cdx.json" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Upload artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -64,3 +67,11 @@ runs:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/dist"
         retention-days: 5
+    - id: upload-artifact1
+      name: Upload artifact1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{inputs.app-path}}
+        path: "${{inputs.app-path}}/dist/application.cdx.json"
+        retention-days: 5
+        archive: false

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -22,6 +22,8 @@ outputs:
   artifact-name:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
+  cyclone-artifact-id:
+    value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
     value:  ${{steps.artifact-name.outputs.cyclone-path}}
 runs:
@@ -67,11 +69,11 @@ runs:
         name: ${{steps.artifact-name.outputs.artifact-name}}
         path: "**/dist"
         retention-days: 5
-    - id: upload-artifact1
+    - id: upload-sbom-artifact
       name: Upload artifact1
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{inputs.app-path}}
+        # name: ${{inputs.app-path}}
         path: "${{inputs.app-path}}/dist/application.cdx.json"
         retention-days: 5
-        # archive: false
+        archive: false

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -23,7 +23,7 @@ outputs:
     description: "Name of the artifact upload"
     value: ${{steps.artifact-name.outputs.artifact-name}}
   cyclone-artifact-id:
-    description: "id of the sbom artifact"
+    description: "ID of the sbom artifact"
     value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
     value: ${{steps.artifact-name.outputs.cyclone-path}}

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -25,7 +25,7 @@ outputs:
   cyclone-artifact-id:
     value: ${{steps.upload-sbom-artifact.outputs.artifact-id}}
   cyclone-path:
-    value:  ${{steps.artifact-name.outputs.cyclone-path}}
+    value: ${{steps.artifact-name.outputs.cyclone-path}}
 runs:
   using: "composite"
   steps:

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: 15m0s
   path:
-    description: "Path to scan with Trivy"
+    description: "Path to scan with Trivy. For scan-type=sbom, this must point to a specific SBOM file (e.g. sbom.cdx.json), not a directory."
     required: false
     default: "."
   scan-type:

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -10,7 +10,15 @@ inputs:
     description: "timeout for trivy scan"
     required: false
     default: 15m0s
-
+  path:
+    description: "Path to scan with Trivy"
+    required: false
+    default: "."
+  scan-type:
+    description: "scan type, e.g. fs or sbom"
+    required: false
+    default: "fs"
+    
 runs:
   using: "composite"
   steps:
@@ -24,8 +32,8 @@ runs:
       env:
         TRIVY_INCLUDE_DEV_DEPS: "true"
       with:
-        scan-type: "fs"
-        scan-ref: "."
+        scan-type: "${{ inputs.scan-type }}"
+        scan-ref: "${{ inputs.path }}"
         format: "json"
         exit-code: "1"
         timeout: "${{ inputs.timeout }}"

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -18,12 +18,12 @@ inputs:
     description: "scan type, e.g. fs or sbom"
     required: false
     default: "fs"
-    
+
 runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      if:  inputs.scan-type  == 'fs'
+      if: inputs.scan-type  == 'fs'
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # Required for vitepress lastUpdated

--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -23,6 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
+      if:  inputs.scan-type  == 'fs'
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # Required for vitepress lastUpdated

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -460,6 +460,9 @@ Output parameters:
 
 1. `MVN_ARTIFACT_ID`: Artifact name of pom.xml
 2. `artifact-name`: Name of the uploaded artifact
+3. `cyclone-artifact-id: id of the sbom artifact
+4. `cyclone-path`: path of the sbom
+
 
 Workflows using that action need the following permissions:
 
@@ -530,6 +533,8 @@ Executes the following steps:
 Output parameters:
 
 1. `artifact-name`: Name of the uploaded artifact
+2. `cyclone-artifact-id: id of the sbom artifact
+3. `cyclone-path`: path of the sbom
 
 Workflows using that action need the following permissions:
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -425,6 +425,8 @@ Executes the following steps:
 Output parameters:
 
 1. `artifact-name`: Name of the uploaded artifact
+2. `cyclone-artifact-id`: ID of the sbom artifact
+3. `cyclone-path`: path of the sbom
 
 Workflows using that action need the following permissions:
 
@@ -460,8 +462,6 @@ Output parameters:
 
 1. `MVN_ARTIFACT_ID`: Artifact name of pom.xml
 2. `artifact-name`: Name of the uploaded artifact
-3. `cyclone-artifact-id`: ID of the sbom artifact
-4. `cyclone-path`: path of the sbom
 
 Workflows using that action need the following permissions:
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -460,7 +460,7 @@ Output parameters:
 
 1. `MVN_ARTIFACT_ID`: Artifact name of pom.xml
 2. `artifact-name`: Name of the uploaded artifact
-3. `cyclone-artifact-id: id of the sbom artifact
+3. `cyclone-artifact-id`: id of the sbom artifact
 4. `cyclone-path`: path of the sbom
 
 
@@ -533,7 +533,7 @@ Executes the following steps:
 Output parameters:
 
 1. `artifact-name`: Name of the uploaded artifact
-2. `cyclone-artifact-id: id of the sbom artifact
+2. `cyclone-artifact-id`: id of the sbom artifact
 3. `cyclone-path`: path of the sbom
 
 Workflows using that action need the following permissions:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -663,4 +663,13 @@ Workflows using that action need the following permissions:
     # Relative Path to the trivyignore files
     # Default: ".trivyignore"
     trivyignore-files: ".trivyignore"
+    # Timeout for Trivy scan
+    # Default: 15m0s
+    timeout: "15m0s"
+    # scan type, e.g. fs or sbom
+    # defualt: fs
+    scan-type: fs
+    # Path to scan with Trivy
+    # Default: .
+    path: "."
 ```

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -463,7 +463,6 @@ Output parameters:
 3. `cyclone-artifact-id`: id of the sbom artifact
 4. `cyclone-path`: path of the sbom
 
-
 Workflows using that action need the following permissions:
 
 | Permission             | Purpose                          |                             Required                             |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -460,7 +460,7 @@ Output parameters:
 
 1. `MVN_ARTIFACT_ID`: Artifact name of pom.xml
 2. `artifact-name`: Name of the uploaded artifact
-3. `cyclone-artifact-id`: id of the sbom artifact
+3. `cyclone-artifact-id`: ID of the sbom artifact
 4. `cyclone-path`: path of the sbom
 
 Workflows using that action need the following permissions:
@@ -532,7 +532,7 @@ Executes the following steps:
 Output parameters:
 
 1. `artifact-name`: Name of the uploaded artifact
-2. `cyclone-artifact-id`: id of the sbom artifact
+2. `cyclone-artifact-id`: ID of the sbom artifact
 3. `cyclone-path`: path of the sbom
 
 Workflows using that action need the following permissions:


### PR DESCRIPTION
# Pull Request

## Changes

- trivy sbom

## Reference

Relates to #297

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : 
- https://github.com/it-at-m/sps/pull/63

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [x] Wrote code and comments in English
- [ ] Coming soon: Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Build actions now expose SBOM/Cyclone outputs: `cyclone-artifact-id` and `cyclone-path`.
  * Trivy scan action now supports configurable `path` and `scan-type` inputs (filesystem vs other modes).
* **Bug Fixes**
  * Maven and npm SBOM artifact publishing was tightened to upload only the generated CycloneDX JSON file.
* **Documentation**
  * Updated action documentation to describe the new SBOM outputs and added Trivy `timeout`, `scan-type`, and `path` configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->