### PR TITLE
feat(pencil): node-version-file 

### DIFF
--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -10,7 +10,10 @@ inputs:
   node-version:
     description: "Node version"
     required: false
-    default: "22"
+  node-version-file:
+    description: "File containing the version Spec of the version to use."
+    required: false
+    default: package.json
   build-cmd:
     description: "Build command to run (e.g. for VuePress use: vuepress build)"
     required: false
@@ -36,6 +39,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.docs-path }}/package.json
         cache: npm
         cache-dependency-path: "${{ inputs.docs-path }}/package-lock.json"
     - name: Setup Pages

--- a/action-templates/actions/action-build-docs/action.yml
+++ b/action-templates/actions/action-build-docs/action.yml
@@ -10,10 +10,6 @@ inputs:
   node-version:
     description: "Node version"
     required: false
-  node-version-file:
-    description: "File containing the version Spec of the version to use."
-    required: false
-    default: package.json
   build-cmd:
     description: "Build command to run (e.g. for VuePress use: vuepress build)"
     required: false

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -8,7 +8,7 @@ inputs:
   node-version-file:
     description: "File containing the version Spec of the version to use."
     required: false
-    default: package.json
+    default: ${{inputs.app-path}}/package.json
   app-path:
     description: "Path to package.json file"
     required: true
@@ -42,7 +42,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        node-version-file: ${{inputs.app-path}}/${{ inputs.node-version-file }}
+        node-version-file: ${{ inputs.node-version-file }}
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"
     - name: Install dependencies

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -5,10 +5,6 @@ inputs:
   node-version:
     description: "node version"
     required: false
-  node-version-file:
-    description: "File containing the version Spec of the version to use."
-    required: false
-    default: package.json
   app-path:
     description: "Path to package.json file"
     required: true

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        node-version-file: ${{ inputs.node-version-file }}
+        node-version-file: ${{inputs.app-path}}/package.json
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"
     - name: Install dependencies

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -8,7 +8,7 @@ inputs:
   node-version-file:
     description: "File containing the version Spec of the version to use."
     required: false
-    default: ${{inputs.app-path}}/package.json
+    default: package.json
   app-path:
     description: "Path to package.json file"
     required: true

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -38,7 +38,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        node-version-file: ${{inputs.app-path}}/package.json
+        node-version-file: ./${{inputs.app-path}}/package.json
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"
     - name: Install dependencies

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -5,7 +5,10 @@ inputs:
   node-version:
     description: "node version"
     required: false
-    default: "22"
+  node-version-file:
+    description: "File containing the version Spec of the version to use."
+    required: false
+    default: package.json
   app-path:
     description: "Path to package.json file"
     required: true
@@ -39,6 +42,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
+        node-version-file:  ${{ inputs.node-version-file }}
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"
     - name: Install dependencies

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        node-version-file: ${{ inputs.node-version-file }}
+        node-version-file: ${{inputs.app-path}}/${{ inputs.node-version-file }}
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"
     - name: Install dependencies

--- a/action-templates/actions/action-npm-build/action.yml
+++ b/action-templates/actions/action-npm-build/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
-        node-version-file:  ${{ inputs.node-version-file }}
+        node-version-file: ${{ inputs.node-version-file }}
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"
     - name: Install dependencies

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -5,7 +5,10 @@ inputs:
   node-version:
     description: "Node version"
     required: false
-    default: "22"
+  node-version-file:
+    description: "File containing the version Spec of the version to use."
+    required: false
+    default: package.json
   app-path:
     description: "Path to package.json file"
     required: true
@@ -32,6 +35,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "${{ inputs.node-version }}"
+        node-version-file: ${{inputs.app-path}}/package.json
         registry-url: "https://registry.npmjs.org"
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -31,7 +31,7 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "${{ inputs.node-version }}"
-        node-version-file: ${{inputs.app-path}}/package.json
+        node-version-file: ./${{inputs.app-path}}/package.json
         registry-url: "https://registry.npmjs.org"
         cache: "npm"
         cache-dependency-path: "./${{inputs.app-path}}/package-lock.json"

--- a/action-templates/actions/action-npm-release/action.yml
+++ b/action-templates/actions/action-npm-release/action.yml
@@ -5,10 +5,6 @@ inputs:
   node-version:
     description: "Node version"
     required: false
-  node-version-file:
-    description: "File containing the version Spec of the version to use."
-    required: false
-    default: package.json
   app-path:
     description: "Path to package.json file"
     required: true

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -74,7 +74,7 @@ Workflows using that action need the following permissions:
     # Default: ./docs
     docs-path: "./docs"
 
-    # Node version. If node-version and node-version-file are both provided the action will use version from node-version.
+    # Node version to use. If node-version and node-version-file are both provided the action will use version from node-version.
     node-version: "22"
 
     # Build command to run (e.g. "vuepress build" for VuePress projects)
@@ -547,7 +547,7 @@ Workflows using that action need the following permissions:
 ```yaml
 - uses: it-at-m/lhm_actions/action-templates/actions/action-npm-build
   with:
-    # Node Version to use.  If node-version and node-version-file are both provided the action will use version from node-version.
+    # Node Version to use. If node-version and node-version-file are both provided the action will use version from node-version.
     node-version: "22"
 
     # Path to package.json

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -74,12 +74,8 @@ Workflows using that action need the following permissions:
     # Default: ./docs
     docs-path: "./docs"
 
-    # Node version
+    # Node version. If node-version and node-version-file are both provided the action will use version from node-version.
     node-version: "22"
-    # File containing the version Spec of the version to use.  Examples: package.json
-    # If node-version and node-version-file are both provided the action will use version from node-version.
-    # Default: "package.json
-    node-version-file: "package.json"
 
     # Build command to run (e.g. "vuepress build" for VuePress projects)
     # Default: build
@@ -551,12 +547,8 @@ Workflows using that action need the following permissions:
 ```yaml
 - uses: it-at-m/lhm_actions/action-templates/actions/action-npm-build
   with:
-    # Node Version to use
-    node-version: "22.11.0"
-    # File containing the version Spec of the version to use.  Examples: package.json
-    # If node-version and node-version-file are both provided the action will use version from node-version.
-    # Default: "package.json
-    node-version-file: "package.json"
+    # Node Version to use.  If node-version and node-version-file are both provided the action will use version from node-version.
+    node-version: "22"
 
     # Path to package.json
     app-path: "."
@@ -601,12 +593,8 @@ Workflows using that action need the following permissions:
 ```yaml
 - uses: it-at-m/lhm_actions/action-templates/actions/action-npm-release
   with:
-    # Node Version to use
+    # Node Version to use. If node-version and node-version-file are both provided the action will use version from node-version.
     node-version: "22"
-    # File containing the version Spec of the version to use.  Examples: package.json
-    # If node-version and node-version-file are both provided the action will use version from node-version.
-    # Default: "package.json
-    node-version-file: "package.json"
 
     # Path to package.json
     # "" would be equal to "./package.json" and "test-frontend" to "./test-frontend/package.json"

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -75,8 +75,11 @@ Workflows using that action need the following permissions:
     docs-path: "./docs"
 
     # Node version
-    # Default: 22
     node-version: "22"
+    # File containing the version Spec of the version to use.  Examples: package.json
+    # If node-version and node-version-file are both provided the action will use version from node-version.
+    # Default: "package.json
+    node-version-file: "package.json"
 
     # Build command to run (e.g. "vuepress build" for VuePress projects)
     # Default: build
@@ -549,8 +552,11 @@ Workflows using that action need the following permissions:
 - uses: it-at-m/lhm_actions/action-templates/actions/action-npm-build
   with:
     # Node Version to use
-    # Default: 22.11.0
     node-version: "22.11.0"
+    # File containing the version Spec of the version to use.  Examples: package.json
+    # If node-version and node-version-file are both provided the action will use version from node-version.
+    # Default: "package.json
+    node-version-file: "package.json"
 
     # Path to package.json
     app-path: "."
@@ -596,8 +602,11 @@ Workflows using that action need the following permissions:
 - uses: it-at-m/lhm_actions/action-templates/actions/action-npm-release
   with:
     # Node Version to use
-    # Default: see action-npm-build
     node-version: "22"
+    # File containing the version Spec of the version to use.  Examples: package.json
+    # If node-version and node-version-file are both provided the action will use version from node-version.
+    # Default: "package.json
+    node-version-file: "package.json"
 
     # Path to package.json
     # "" would be equal to "./package.json" and "test-frontend" to "./test-frontend/package.json"


### PR DESCRIPTION
Added input for node version file in action.yml.

# Pull Request

## Changes

- remove default node-version
- set node version from package.json

## Reference

Relates to https://github.com/it-at-m/lhm_actions/issues/299

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : 
- https://github.com/it-at-m/refarch-templates/pull/1698

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [x] Wrote code and comments in English
- [ ] Coming soon: Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs/build/release actions can now automatically determine the Node.js version from the target project’s `package` configuration.
  * When both are provided, the explicit Node.js version input takes precedence over the detected version.

* **Behavior Changes**
  * The `node-version` input no longer has a built-in default; callers must provide it or rely on auto-detection.

* **Documentation**
  * Updated action examples and comments to reflect the updated Node.js version selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->