### PR TITLE
fix(pencil): java version from pom.xml

### DIFF
--- a/.github/workflows/test-action-maven-build.yml
+++ b/.github/workflows/test-action-maven-build.yml
@@ -27,3 +27,4 @@ jobs:
       - uses: ./action-templates/actions/action-maven-build
         with:
           app-path: __tests__/maven-helloworld
+          java-version: "21"

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -52,7 +52,7 @@ runs:
         fi
 
         # Save the version to step outputs
-        echo "java-version=$JAVA_VERSION" >> "$GITHUB_OUTPUT"        
+        echo "java-version=$JAVA_VERSION" >> "$GITHUB_OUTPUT"
     - name: Set up JDK
       if: inputs.codeql-language == 'java-kotlin' && inputs.codeql-buildmode == 'autobuild'
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: "security-and-quality"
   java-version:
-    description: "Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild)"
+    description: "Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild). If not set extract the version from the `pom.xml` on the attribute `java.version`."
     required: false
   path:
     description: "Path to scan files in"

--- a/action-templates/actions/action-codeql/action.yml
+++ b/action-templates/actions/action-codeql/action.yml
@@ -19,7 +19,6 @@ inputs:
   java-version:
     description: "Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild)"
     required: false
-    default: "21"
   path:
     description: "Path to scan files in"
     required: false
@@ -32,11 +31,33 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+    - name: Extract Java Version from pom.xml
+      id: get-java-version
+      if: inputs.codeql-language == 'java-kotlin' && inputs.codeql-buildmode == 'autobuild'
+      shell: bash
+      env:
+        APP_PATH: ${{inputs.path}}
+        JAVA_VERSION: ${{ inputs.java-version }}
+      run: |
+        # Check if the input java-version is empty
+        if [ -z "$JAVA_VERSION" ]; then
+            # Extract from pom.xml if input is empty
+            JAVA_VERSION=$(grep -oP '(?<=<(java.version)>)[^<]+' "$APP_PATH/pom.xml" | head -n 1)
+        fi
+
+        # Fail the build if no version could be determined at all
+        if [ -z "$JAVA_VERSION" ]; then
+            echo "Error: Java version could not be determined!"
+            exit 1
+        fi
+
+        # Save the version to step outputs
+        echo "java-version=$JAVA_VERSION" >> "$GITHUB_OUTPUT"        
     - name: Set up JDK
       if: inputs.codeql-language == 'java-kotlin' && inputs.codeql-buildmode == 'autobuild'
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
-        java-version: ${{ inputs.java-version }}
+        java-version: ${{ steps.get-java-version.outputs.java-version }}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "${{ inputs.path }}/pom.xml"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -3,7 +3,7 @@ description: "Executes a Maven build and uploads the generated artifact to Maven
 
 inputs:
   java-version:
-    description: "Java version to use for the build"
+    description: "Java version to use for the build. If not set extract the version from the `pom.xml` on the attribute `java.version`."
     required: false
   app-path:
     description: "Path to the project’s pom.xml file"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -30,11 +30,36 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+    - name: Extract Java Version from pom.xml
+      id: get-java-version
+      shell: bash
+      env:
+        APP_PATH: ${{inputs.app-path}}
+      run: |
+        # Check if the input java-version is empty
+        if [ -z "${{ inputs.java-version }}" ]; then
+            # Extract from pom.xml if input is empty
+            VERSION=$(grep -oP '(?<=<(java.version)>)[^<]+' "$APP_PATH/pom.xml" | head -n 1)
+        else
+            # Use the provided input
+            VERSION="${{ inputs.java-version }}"
+        fi
+        
+        # Fail the build if no version could be determined at all
+        if [ -z "$VERSION" ]; then
+            echo "Error: Java version could not be determined!"
+            exit 1
+        fi
+        
+        # Save the version to step outputs
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          
+          
+
     - name: Set up JDK
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
-        java-version: ${{ inputs.java-version }}
-        java-version-file: ${{inputs.app-path}}/${{inputs.java-version-file}}
+        java-version:  ${{ steps.get-java-version.outputs.version }}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "./${{inputs.app-path}}/pom.xml"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -34,7 +34,7 @@ runs:
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         java-version: ${{ inputs.java-version }}
-        java-verion-file: ${{inputs.app-path}}/${{inputs.java-version-file}}
+        java-version-file: ${{inputs.app-path}}/${{inputs.java-version-file}}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "./${{inputs.app-path}}/pom.xml"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -5,11 +5,13 @@ inputs:
   java-version:
     description: "Java version to use for the build"
     required: false
-    default: "21"
+  java-version-file:
+    description: "The path to a file containing java version."
+    default: "pom.xml"
+    required: false
   app-path:
     description: "Path to the project’s pom.xml file"
     required: true
-
 outputs:
   artifact-name:
     description: "Name of the artifact upload"
@@ -32,6 +34,7 @@ runs:
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         java-version: ${{ inputs.java-version }}
+        java-verion-file: ${{inputs.app-path}}/${{inputs.java-version-file}}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "./${{inputs.app-path}}/pom.xml"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -35,31 +35,27 @@ runs:
       shell: bash
       env:
         APP_PATH: ${{inputs.app-path}}
+        JAVA_VERSION: ${{ inputs.java-version }}
       run: |
         # Check if the input java-version is empty
-        if [ -z "${{ inputs.java-version }}" ]; then
+        if [ -z "$JAVA_VERSION" ]; then
             # Extract from pom.xml if input is empty
-            VERSION=$(grep -oP '(?<=<(java.version)>)[^<]+' "$APP_PATH/pom.xml" | head -n 1)
-        else
-            # Use the provided input
-            VERSION="${{ inputs.java-version }}"
+            JAVA_VERSION=$(grep -oP '(?<=<(java.version)>)[^<]+' "$APP_PATH/pom.xml" | head -n 1)
         fi
         
         # Fail the build if no version could be determined at all
-        if [ -z "$VERSION" ]; then
+        if [ -z "$JAVA_VERSION" ]; then
             echo "Error: Java version could not be determined!"
             exit 1
         fi
         
         # Save the version to step outputs
-        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          
-          
-
+        echo "java-version=$JAVA_VERSION" >> "$GITHUB_OUTPUT"
+        
     - name: Set up JDK
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
-        java-version:  ${{ steps.get-java-version.outputs.version }}
+        java-version:  ${{ steps.get-java-version.outputs.java-version }}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "./${{inputs.app-path}}/pom.xml"

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -5,10 +5,6 @@ inputs:
   java-version:
     description: "Java version to use for the build"
     required: false
-  java-version-file:
-    description: "The path to a file containing java version."
-    default: "pom.xml"
-    required: false
   app-path:
     description: "Path to the project’s pom.xml file"
     required: true

--- a/action-templates/actions/action-maven-build/action.yml
+++ b/action-templates/actions/action-maven-build/action.yml
@@ -42,20 +42,20 @@ runs:
             # Extract from pom.xml if input is empty
             JAVA_VERSION=$(grep -oP '(?<=<(java.version)>)[^<]+' "$APP_PATH/pom.xml" | head -n 1)
         fi
-        
+
         # Fail the build if no version could be determined at all
         if [ -z "$JAVA_VERSION" ]; then
             echo "Error: Java version could not be determined!"
             exit 1
         fi
-        
+
         # Save the version to step outputs
         echo "java-version=$JAVA_VERSION" >> "$GITHUB_OUTPUT"
-        
+
     - name: Set up JDK
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
-        java-version:  ${{ steps.get-java-version.outputs.java-version }}
+        java-version: ${{ steps.get-java-version.outputs.java-version }}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "./${{inputs.app-path}}/pom.xml"

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -3,7 +3,7 @@ description: "Creates a Maven release pull request"
 
 inputs:
   java-version:
-    description: "Java version to use for the build"
+    description: "Java version to use for the build. If not set extract the version from the `pom.xml` on the attribute `java.version`."
     required: false
   app-path:
     description: "Path to the project’s pom.xml file"

--- a/action-templates/actions/action-maven-release/action.yml
+++ b/action-templates/actions/action-maven-release/action.yml
@@ -5,7 +5,6 @@ inputs:
   java-version:
     description: "Java version to use for the build"
     required: false
-    default: "21"
   app-path:
     description: "Path to the project’s pom.xml file"
     required: true
@@ -54,10 +53,31 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: true
+    - name: Extract Java Version from pom.xml
+      id: get-java-version
+      shell: bash
+      env:
+        APP_PATH: ${{inputs.app-path}}
+        JAVA_VERSION: ${{ inputs.java-version }}
+      run: |
+        # Check if the input java-version is empty
+        if [ -z "$JAVA_VERSION" ]; then
+            # Extract from pom.xml if input is empty
+            JAVA_VERSION=$(grep -oP '(?<=<(java.version)>)[^<]+' "$APP_PATH/pom.xml" | head -n 1)
+        fi
+
+        # Fail the build if no version could be determined at all
+        if [ -z "$JAVA_VERSION" ]; then
+            echo "Error: Java version could not be determined!"
+            exit 1
+        fi
+
+        # Save the version to step outputs
+        echo "java-version=$JAVA_VERSION" >> "$GITHUB_OUTPUT"
     - name: Set up JDK
       uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
-        java-version: ${{ inputs.java-version }}
+        java-version: ${{ steps.get-java-version.outputs.java-version }}
         distribution: "temurin"
         cache: "maven"
         cache-dependency-path: "./${{ inputs.app-path}}/pom.xml"

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -312,8 +312,7 @@ Workflows using that action need the following permissions:
     # Default: security-and-quality
     codeql-query: "security-and-quality"
 
-    # Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild)
-    # Default: 21
+    # Temurin JDK version to use for autobuild (only when codeql-language is java-kotlin and codeql-build is set to autobuild). If not set extract the version from the `pom.xml` on the attribute `java.version`.
     java-version: "21"
 
     # Path to scan files in
@@ -441,8 +440,7 @@ Workflows using that action need the following permissions:
 ```yaml
 - uses: it-at-m/lhm_actions/action-templates/actions/action-maven-build
   with:
-    # Java Version to use
-    # Default: 21
+    # Java Version to use. If not set extract the version from the `pom.xml` on the attribute `java.version`.
     java-version: "21"
 
     # Path to pom.xml
@@ -477,8 +475,7 @@ Workflows using that action need the following permissions:
 ```yaml
 - uses: it-at-m/lhm_actions/action-templates/actions/action-maven-release
   with:
-    # Java Version to use
-    # Default: 21
+    # Java Version to use. If not set extract the version from the `pom.xml` on the attribute `java.version`.
     java-version: "21"
 
     # Path to pom.xml


### PR DESCRIPTION
# Pull Request

## Changes

- extract java version from pom

## Reference

Relates to https://github.com/it-at-m/lhm_actions/issues/300

### Testing

URL to pull request or branch for testing your changes in https://github.com/it-at-m/refarch-templates/pull/1699
## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [ ] Wrote code and comments in English
- [ ] Coming soon: Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maven build, Maven release, and applicable CodeQL workflows can now automatically detect the Java version from `pom.xml` when one isn’t provided.
  * Workflows clearly report an error when no Java version can be determined.
  * Maven test builds now explicitly use Java 21.

* **Documentation**
  * Updated action usage guidance to explain Java version detection and CodeQL-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->