### PR TITLE
fix: Add base input to paths-filter action

### DIFF
--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -2,6 +2,10 @@ name: "Execute paths-filter"
 description: "Execute paths-filter with input of filters"
 
 inputs:
+  base: 
+    description: "Branch, tag, or commit SHA against which the changes will be detected."
+    required: false
+    default: ''
   filters:
     description: "Defines filters applied to detected changed files"
     required: false
@@ -41,3 +45,4 @@ runs:
       uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
       with:
         filters: ${{ inputs.filters }}
+        base: ${{ inputs.base }}

--- a/action-templates/actions/action-filter/action.yml
+++ b/action-templates/actions/action-filter/action.yml
@@ -2,10 +2,10 @@ name: "Execute paths-filter"
 description: "Execute paths-filter with input of filters"
 
 inputs:
-  base: 
+  base:
     description: "Branch, tag, or commit SHA against which the changes will be detected."
     required: false
-    default: ''
+    default: ""
   filters:
     description: "Defines filters applied to detected changed files"
     required: false

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -271,6 +271,9 @@ Workflows using that action need the following permissions:
     filters: |
       src:
         - 'src/**'
+    # Branch, tag, or commit SHA against which the changes will be detected.
+    # default ''
+    base: ''
 
   # run only if some file in 'src' folder was changed
 - if: steps.changes.outputs.src == 'true'


### PR DESCRIPTION
# Pull Request

## Changes

- Add base input to paths-filter action

## Reference

Relates to https://github.com/it-at-m/lhm_actions/issues/33

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : https://github.com/it-at-m/refarch-templates/pull/1700

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [x] Wrote code and comments in English
- [ ] Coming soon: Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optional **base** input (branch, tag, or commit SHA) to control what reference is used for detecting changed files during path filtering.
  * Path change detection can now be evaluated against a specified reference instead of relying only on the default behavior.

* **Documentation**
  * Updated the `action-filter` usage example to include the new optional **base** input and its empty-string default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->