### PR TITLE
fix: trivy als report datei

### DIFF
--- a/action-templates/actions/action-trivy/action.yml
+++ b/action-templates/actions/action-trivy/action.yml
@@ -52,9 +52,9 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
-        name: trivy-report
         path: trivy-report.json
         retention-days: 7
+        archive: false
 
     - name: Upload Trivy scan results to GitHub Security tab
       if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}


### PR DESCRIPTION
# Pull Request

## Changes

-trivy als report datei

Test https://github.com/it-at-m/refarch-templates/actions/runs/29403830376
also es sieht genauso aus wie bei npm build sbom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability scan report uploads by preserving the generated report in its original format.
  * Vulnerability scan artifacts continue to be retained for seven days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->