### PR TITLE
fix: Refactor action.yml to clean up actionlint setup

### DIFF
--- a/.github/workflows/test-action-actionlint.yml
+++ b/.github/workflows/test-action-actionlint.yml
@@ -36,5 +36,3 @@ jobs:
           persist-credentials: false
       - name: test-actionlint-with-display-findings-false
         uses: ./action-templates/actions/action-actionlint
-        with:
-          display-findings: false

--- a/.github/workflows/test-action-actionlint.yml
+++ b/.github/workflows/test-action-actionlint.yml
@@ -24,15 +24,3 @@ jobs:
           persist-credentials: false
       - name: test-actionlint-with-default-settings
         uses: ./action-templates/actions/action-actionlint
-
-  test-actionlint-with-display-findings-false:
-    name: test-actionlint-with-display-findings-false
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout-local-actions
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: test-actionlint-with-display-findings-false
-        uses: ./action-templates/actions/action-actionlint

--- a/action-templates/actions/action-actionlint/action.yml
+++ b/action-templates/actions/action-actionlint/action.yml
@@ -23,7 +23,6 @@ runs:
       with:
         persist-credentials: false
 
-        
     - name: Download actionlint
       id: get_actionlint
       env:
@@ -34,11 +33,11 @@ runs:
         if [[ "$DISPLAY_FINDINGS" == "true" ]]; then
           echo "::add-matcher::$PROBLEM_MATCHER_PATH"
         fi
- #       bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $VERSION
+      #       bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $VERSION
       shell: bash
     - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b #v0.1.3
   #  - name: Check GitHub action files
- #     env:
- #       ACTION_LINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
- #     run: $ACTION_LINT_EXECUTABLE -color
- #     shell: bash
+  #     env:
+  #       ACTION_LINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+  #     run: $ACTION_LINT_EXECUTABLE -color
+  #     shell: bash

--- a/action-templates/actions/action-actionlint/action.yml
+++ b/action-templates/actions/action-actionlint/action.yml
@@ -1,20 +1,6 @@
 name: "Lint actions"
 description: "Lints GitHub workflow files using actionlint"
 
-inputs:
-  version:
-    description: "Version of actionlint to use"
-    required: false
-    default: "latest"
-  display-findings: # requires additional setup, see https://github.com/rhysd/actionlint/blob/main/docs/usage.md#problem-matchers for more information
-    description: "Whether to display findings in PR UI or not"
-    required: false
-    default: "true"
-  problem-matcher-path:
-    description: "Path to the problem matcher configuration file when using display-findings: true"
-    required: false
-    default: ".github/problem-matcher.json"
-
 runs:
   using: "composite"
   steps:
@@ -22,22 +8,4 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-
-    - name: Download actionlint
-      id: get_actionlint
-      env:
-        DISPLAY_FINDINGS: ${{ inputs.display-findings }}
-        PROBLEM_MATCHER_PATH: ${{ inputs.problem-matcher-path }}
-        VERSION: ${{ inputs.version }}
-      run: |
-        if [[ "$DISPLAY_FINDINGS" == "true" ]]; then
-          echo "::add-matcher::$PROBLEM_MATCHER_PATH"
-        fi
-      #       bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $VERSION
-      shell: bash
     - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b #v0.1.3
-  #  - name: Check GitHub action files
-  #     env:
-  #       ACTION_LINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
-  #     run: $ACTION_LINT_EXECUTABLE -color
-  #     shell: bash

--- a/action-templates/actions/action-actionlint/action.yml
+++ b/action-templates/actions/action-actionlint/action.yml
@@ -22,6 +22,8 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+
+        
     - name: Download actionlint
       id: get_actionlint
       env:
@@ -32,10 +34,11 @@ runs:
         if [[ "$DISPLAY_FINDINGS" == "true" ]]; then
           echo "::add-matcher::$PROBLEM_MATCHER_PATH"
         fi
-        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $VERSION
+ #       bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $VERSION
       shell: bash
-    - name: Check GitHub action files
-      env:
-        ACTION_LINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
-      run: $ACTION_LINT_EXECUTABLE -color
-      shell: bash
+    - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b #v0.1.3
+  #  - name: Check GitHub action files
+ #     env:
+ #       ACTION_LINT_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+ #     run: $ACTION_LINT_EXECUTABLE -color
+ #     shell: bash

--- a/action-templates/actions/action-actionlint/action.yml
+++ b/action-templates/actions/action-actionlint/action.yml
@@ -8,4 +8,4 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b #v0.1.3
+    - uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b # v0.1.3

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -28,22 +28,12 @@ Workflows using that action need the following permissions:
 | Permission       | Purpose                      | Required |
 | ---------------- | ---------------------------- | :------: |
 | `contents: read` | Checkout repository contents |   Yes    |
+| `pull-requests: write` |  needed to annotate the files in a pull request with comments |   Yes    |
 
 <!-- prettier-ignore -->
 ```yaml
 - uses: it-at-m/lhm_actions/action-templates/actions/action-actionlint
-  with:
-    # Version of actionlint to use
-    # Default: latest
-    version: "latest"
 
-    # Whether to display findings in PR UI or not
-    # Default: true
-    display-findings: "true"
-
-    # Path to the problem matcher file when using display-findings: true
-    # Default: .github/problem-matcher.json
-    problem-matcher-path: ".github/problem-matcher.json"
 ```
 
 **Note**: The usage of `display-findings: true` requires additional setup.

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -25,10 +25,10 @@ Executes the following steps:
 
 Workflows using that action need the following permissions:
 
-| Permission       | Purpose                      | Required |
-| ---------------- | ---------------------------- | :------: |
-| `contents: read` | Checkout repository contents |   Yes    |
-| `pull-requests: write` |  needed to annotate the files in a pull request with comments |   Yes    |
+| Permission             | Purpose                                                      | Required |
+| ---------------------- | ------------------------------------------------------------ | :------: |
+| `contents: read`       | Checkout repository contents                                 |   Yes    |
+| `pull-requests: write` | needed to annotate the files in a pull request with comments |   Yes    |
 
 <!-- prettier-ignore -->
 ```yaml

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -21,7 +21,7 @@ Executes the following steps:
 
 1. Checkout code
 2. Run actionlint on your workflow files
-Workflows using that action need the following permissions:
+   Workflows using that action need the following permissions:
 
 | Permission             | Purpose                                                      | Required |
 | ---------------------- | ------------------------------------------------------------ | :------: |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -21,7 +21,8 @@ Executes the following steps:
 
 1. Checkout code
 2. Run actionlint on your workflow files
-   Workflows using that action need the following permissions:
+
+Workflows using that action need the following permissions:
 
 | Permission             | Purpose                                                      | Required |
 | ---------------------- | ------------------------------------------------------------ | :------: |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -22,7 +22,7 @@ Executes the following steps:
 1. Checkout code
 2. Download specified actionlint version
 3. Run actionlint on your workflow files
-
+2. Run actionlint on your workflow files
 Workflows using that action need the following permissions:
 
 | Permission             | Purpose                                                      | Required |

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -20,8 +20,6 @@ Action to lint your workflows using [actionlint](https://github.com/rhysd/action
 Executes the following steps:
 
 1. Checkout code
-2. Download specified actionlint version
-3. Run actionlint on your workflow files
 2. Run actionlint on your workflow files
 Workflows using that action need the following permissions:
 


### PR DESCRIPTION
Removed commented-out code for checking GitHub action files and updated actionlint usage.

# Pull Request

## Changes

- change action lint to action

## Reference

Relates to https://github.com/it-at-m/lhm_actions/issues/275

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) :  https://github.com/it-at-m/sps-test/pull/16/changes

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [x] Wrote code and comments in English
- [ ] Coming soon: Added unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Updated the action-linting composite action to delegate linting to the standard actionlint implementation.
  - Removed support for the action inputs `version`, `display-findings`, and `problem-matcher-path`.
- **Documentation**
  - Updated workflow permissions and examples to include `pull-requests: write` for PR comment annotations.
- **Tests**
  - Added CI coverage for actionlint with default settings to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->