### PR TITLE
feat(build-image): Add support for multi-architecture build

### DIFF
--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: |
       type=raw,value=latest
   image-labels:
-    description: "Labels to add to image"
+    description: "Labels or OCI manifest annotations to add to image"
     required: false
     default: |
       org.opencontainers.image.description=See ${{ github.server_url }}/${{ github.repository }}
@@ -57,13 +57,16 @@ runs:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}
         password: ${{ inputs.registry-password }}
-    - name: Extract metadata (tags, labels) for Docker
+    - name: Extract metadata (tags, labels, annotations) for Docker
       id: meta
       uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+      env:
+        DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       with:
         images: "${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image-name }}"
-        tags: ${{inputs.image-tags}}
-        labels: ${{inputs.image-labels}}
+        tags: ${{ inputs.image-tags }}
+        labels: ${{ inputs.image-labels }}
+        annotations: ${{ inputs.image-labels }}
     - name: Build and push image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
@@ -72,4 +75,5 @@ runs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
         github-token: ${{ github.token }}

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -31,14 +31,10 @@ inputs:
   artifact-name:
     description: "Name of artifact to download "
     required: true
-  target-platforms:
-    description: "List of comma separated target Docker platforms to build images for, e.g. linux/amd64,linux/arm64"
+  platforms:
+    description: "List of comma separated Docker platforms to build images for, e.g. linux/amd64,linux/arm64"
     required: false
     default: linux/amd64
-  emulated-platforms:
-    description: "List of comma separated QEMU architectures to enable for emulation, e.g. arm64 when building linux/arm64 target on amd64 GitHub Runner)"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -52,12 +48,9 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
     - name: Set up QEMU
-      if: inputs.emulated-platforms != ''
-      uses: docker/setup-qemu-action@v4 # v4.2.0
-      with:
-        platforms: ${{ inputs.qemu-platforms }}
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4 # v4.2.0
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
     - name: Login to registry
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
@@ -71,12 +64,11 @@ runs:
         images: "${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image-name }}"
         tags: ${{inputs.image-tags}}
         labels: ${{inputs.image-labels}}
-
     - name: Build and push image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ./${{ inputs.path }} # zizmor: ignore[template-injection]
-        platforms: ${{ inputs.target-platforms }}
+        platforms: ${{ inputs.platforms }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/action-templates/actions/action-build-image/action.yml
+++ b/action-templates/actions/action-build-image/action.yml
@@ -31,6 +31,14 @@ inputs:
   artifact-name:
     description: "Name of artifact to download "
     required: true
+  target-platforms:
+    description: "List of comma separated target Docker platforms to build images for, e.g. linux/amd64,linux/arm64"
+    required: false
+    default: linux/amd64
+  emulated-platforms:
+    description: "List of comma separated QEMU architectures to enable for emulation, e.g. arm64 when building linux/arm64 target on amd64 GitHub Runner)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -43,6 +51,13 @@ runs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact-name }}
+    - name: Set up QEMU
+      if: inputs.emulated-platforms != ''
+      uses: docker/setup-qemu-action@v4 # v4.2.0
+      with:
+        platforms: ${{ inputs.qemu-platforms }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4 # v4.2.0
     - name: Login to registry
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
@@ -61,6 +76,7 @@ runs:
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ./${{ inputs.path }} # zizmor: ignore[template-injection]
+        platforms: ${{ inputs.target-platforms }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -85,10 +85,10 @@ Action to build a multi-architecture Docker image with multi-architecture suppor
 Executes the following steps:
 
 1. Checkout code
-2. Setup QEMU emulation for multi-architecture builds
+2. Setup QEMU emulation to support multi-architecture builds
 3. Setup buildx build tool
 4. Login to Registry
-5. Extract metadata (tags, labels) for Docker
+5. Extract metadata (tags, labels, annotations) for Docker
 6. Build and push image to a registry
 
 Workflows using that action need the following permissions:

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -131,14 +131,10 @@ Workflows using that action need the following permissions:
     # Name of the artifact to download
     artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
 
-    # List of comma separated target Docker platforms to build images for, e.g. linux/amd64,linux/arm64
+    # List of comma separated Docker platforms to build images for, e.g. linux/amd64,linux/arm64
     # Note: This also requires a compatible base image in the Dockerfile of the application
     # Default: linux/amd64
-    target-platforms: linux/amd64,linux/arm64
-
-    # List of comma separated QEMU architectures to enable for emulation, e.g. "arm64" required for "linux/arm64" target on a amd64 GitHub runner
-    # Default: ""
-    emulated-platforms: arm64
+    platforms: linux/amd64,linux/arm64
 ```
 
 ### action-checkout

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -76,17 +76,20 @@ Workflows using that action need the following permissions:
     # disallow external scripts during npm ci https://about.gitlab.com/blog/pipeline-security-lessons-from-march-supply-chain-incidents/#use-case-2-detect-dependency-tampering-and-lockfile-manipulation
     # Default: "--ignore-scripts"
     npm-ci-parameter: "--ignore-scripts"
+```
 
 ### action-build-image
 
-Action to build a Docker image and push it to a registry.
+Action to build a multi-architecture Docker image with multi-architecture support and push it to a registry.
 
 Executes the following steps:
 
 1. Checkout code
-2. Login to Registry
-3. Extract metadata (tags, labels) for Docker
-4. Build and push image to a registry
+2. Setup QEMU emulation for multi-architecture builds
+3. Setup buildx build tool
+4. Login to Registry
+5. Extract metadata (tags, labels) for Docker
+6. Build and push image to a registry
 
 Workflows using that action need the following permissions:
 
@@ -127,6 +130,15 @@ Workflows using that action need the following permissions:
 
     # Name of the artifact to download
     artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
+
+    # List of comma separated target Docker platforms to build images for, e.g. linux/amd64,linux/arm64
+    # Note: This also requires a compatible base image in the Dockerfile of the application
+    # Default: linux/amd64
+    target-platforms: linux/amd64,linux/arm64
+
+    # List of comma separated QEMU architectures to enable for emulation, e.g. "arm64" required for "linux/arm64" target on a amd64 GitHub runner
+    # Default: ""
+    emulated-platforms: arm64
 ```
 
 ### action-checkout
@@ -565,6 +577,7 @@ Workflows using that action need the following permissions:
     # disallow external scripts during npm ci https://about.gitlab.com/blog/pipeline-security-lessons-from-march-supply-chain-incidents/#use-case-2-detect-dependency-tampering-and-lockfile-manipulation
     # Default: "--ignore-scripts=true"
     npm-ci-parameter: "--ignore-scripts=true"
+```
 
 ### action-npm-release
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -116,7 +116,7 @@ Workflows using that action need the following permissions:
     # Default: type=raw,value=latest
     image-tags: type=raw,value=latest
 
-    # Labels to add to image  
+    # Labels or OCI manifest annotations to add to image
     # Default: org.opencontainers.image.description=See ${{ github.server_url }}/${{ github.repository }}
     # Optional
     image-labels: |


### PR DESCRIPTION
# Pull Request

## Changes

- Added QEMU and buildx setup to action
- Added `platforms` as inputs to action (default is `amd64` only)
- Fix missing code block ends in documentation
- Updated documentation

## Reference

Closes #318

### Testing

URL to pull request or branch for testing your changes in [sps-repo](https://github.com/it-at-m/sps) : ...

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Documented changes in documentation files (docs/action.md, docs/workflows.md and/or docs/deployment.md)
- [x] Tested changes with sample project <https://github.com/it-at-m/sps>

### Code

- [x] Wrote code and comments in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building images for multiple platforms, including AMD64 and ARM64.
  - Added a configurable `platforms` option, defaulting to Linux AMD64.
  - Added support for OCI manifest annotations alongside image labels.
  - Automatically prepares the environment for multi-platform image builds.
- **Documentation**
  - Updated usage examples and clarified multi-architecture build configuration.
  - Fixed formatting in the npm build example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->